### PR TITLE
add optional attribute to Include type

### DIFF
--- a/src/main/xsd/logback.xsd
+++ b/src/main/xsd/logback.xsd
@@ -38,6 +38,7 @@
 	</xsd:complexType>
 
 	<xsd:complexType name="Include">
+		<xsd:attribute name="optional" use="optional" type="xsd:boolean"/>
 		<xsd:attribute name="file" use="optional" type="xsd:string"/>
 		<xsd:attribute name="resource" use="optional" type="xsd:string"/>
 		<xsd:attribute name="url" use="optional" type="xsd:string"/>


### PR DESCRIPTION
see http://logback.qos.ch/manual/configuration.html

If it cannot find the file to be included, logback will complain by printing a status message. In case the included file is optional, you can suppress the error message by setting optional attribute to true in the <include> element.

<include optional="true" ..../>
